### PR TITLE
Allow for local dns resolution with a custom dialer

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -845,6 +845,11 @@ type auth interface {
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
 func dialConnection(ctx context.Context, c *Connector, p connectParams) (conn net.Conn, err error) {
+	if c.Dialer != nil {
+		d := c.getDialer(&p)
+		addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
+		return d.DialContext(ctx, "tcp", addr)
+	}
 	var ips []net.IP
 	ip := net.ParseIP(p.host)
 	if ip == nil {

--- a/tds.go
+++ b/tds.go
@@ -847,7 +847,7 @@ type auth interface {
 func dialConnection(ctx context.Context, c *Connector, p connectParams) (conn net.Conn, err error) {
 	// if the dialer has been updated, the dialer may be proxying to a different network, and so the
 	// dialer should be used to connect so the DNS is resolved within the right network
-	if c.Dialer != nil {
+	if c != nil && c.Dialer != nil {
 		d := c.getDialer(&p)
 		addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
 		return d.DialContext(ctx, "tcp", addr)

--- a/tds.go
+++ b/tds.go
@@ -845,11 +845,14 @@ type auth interface {
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
 func dialConnection(ctx context.Context, c *Connector, p connectParams) (conn net.Conn, err error) {
+	// if the dialer has been updated, use the dialer before resolving the DNS. Otherwise,
+	// proxied connections where only the proxy can reach the network to resolve DNS, will fail.
 	if c.Dialer != nil {
 		d := c.getDialer(&p)
 		addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
 		return d.DialContext(ctx, "tcp", addr)
 	}
+
 	var ips []net.IP
 	ip := net.ParseIP(p.host)
 	if ip == nil {

--- a/tds.go
+++ b/tds.go
@@ -845,19 +845,18 @@ type auth interface {
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
 func dialConnection(ctx context.Context, c *Connector, p connectParams) (conn net.Conn, err error) {
-	// if the dialer has been updated, use the dialer before resolving the DNS. Otherwise,
-	// proxied connections where only the proxy can reach the network to resolve DNS, will fail.
-	if c.Dialer != nil {
-		d := c.getDialer(&p)
-		addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
-		return d.DialContext(ctx, "tcp", addr)
-	}
-
 	var ips []net.IP
 	ip := net.ParseIP(p.host)
 	if ip == nil {
 		ips, err = net.LookupIP(p.host)
 		if err != nil {
+			// if the dialer has been updated and DNS can not be resolved, the dialer may be trying to
+			// proxy to a different network where the domain name is local. Try to connect via the custom dialer
+			if c.Dialer != nil {
+				d := c.getDialer(&p)
+				addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
+				return d.DialContext(ctx, "tcp", addr)
+			}
 			return
 		}
 	} else {

--- a/tds.go
+++ b/tds.go
@@ -845,16 +845,17 @@ type auth interface {
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
 func dialConnection(ctx context.Context, c *Connector, p connectParams) (conn net.Conn, err error) {
-	// if the dialer has been updated, the dialer may be proxying to a different network, and so the
-	// dialer should be used to connect so the DNS is resolved within the right network
-	if c != nil && c.Dialer != nil {
-		d := c.getDialer(&p)
-		addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
-		return d.DialContext(ctx, "tcp", addr)
-	}
 	var ips []net.IP
 	ip := net.ParseIP(p.host)
 	if ip == nil {
+		// if the dialer has been updated, the dialer may be proxying to a different network, and so the
+		// dialer should be used to connect so the DNS is resolved within the right network
+		if c != nil && c.Dialer != nil {
+			d := c.getDialer(&p)
+			addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
+			return d.DialContext(ctx, "tcp", addr)
+		}
+
 		ips, err = net.LookupIP(p.host)
 		if err != nil {
 			return

--- a/tds.go
+++ b/tds.go
@@ -845,18 +845,18 @@ type auth interface {
 // list of IP addresses.  So if there is more than one, try them all and
 // use the first one that allows a connection.
 func dialConnection(ctx context.Context, c *Connector, p connectParams) (conn net.Conn, err error) {
+	// if the dialer has been updated, the dialer may be proxying to a different network, and so the
+	// dialer should be used to connect so the DNS is resolved within the right network
+	if c.Dialer != nil {
+		d := c.getDialer(&p)
+		addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
+		return d.DialContext(ctx, "tcp", addr)
+	}
 	var ips []net.IP
 	ip := net.ParseIP(p.host)
 	if ip == nil {
 		ips, err = net.LookupIP(p.host)
 		if err != nil {
-			// if the dialer has been updated and DNS can not be resolved, the dialer may be trying to
-			// proxy to a different network where the domain name is local. Try to connect via the custom dialer
-			if c.Dialer != nil {
-				d := c.getDialer(&p)
-				addr := net.JoinHostPort(p.host, strconv.Itoa(int(resolveServerPort(p.port))))
-				return d.DialContext(ctx, "tcp", addr)
-			}
 			return
 		}
 	} else {

--- a/tds_test.go
+++ b/tds_test.go
@@ -616,6 +616,7 @@ func TestDialConnectionCustomDialer(t *testing.T) {
 	SetLogger(testLogger{t})
 
 	params := testConnParams(t)
+	params.host = "mssql"
 	connector, err := NewConnector(params.toUrl().String())
 	if err != nil {
 		t.Error(err)

--- a/tds_test.go
+++ b/tds_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"runtime"
 	"testing"
+	"time"
 )
 
 type MockTransport struct {
@@ -608,5 +609,42 @@ func runBatch(t testing.TB, p connectParams) {
 			t.Error("Invalid value returned, should be 1", value)
 			return
 		}
+	}
+}
+
+func TestDialConnectionCustomDialer(t *testing.T) {
+	SetLogger(testLogger{t})
+
+	params := testConnParams(t)
+	connector, err := NewConnector(params.toUrl().String())
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	// if a dialer is specified, the dialer should be used to make the connection
+	mock := NewMockTransportDialer(
+		[]string{},
+		[]string{},
+	)
+	connector.Dialer = mock
+	if mock.count != 0 {
+		t.Error("expecting no connections")
+	}
+
+	conn, err := dialConnection(ctx, connector, params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if mock.count != 1 {
+		t.Error("expecting 1 connection")
+	}
+
+	err = conn.Close()
+	if err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
**Overview**
If the custom dialer updates the transport to proxy the mssql connection, and only the proxy can reach the network that mssql is running in, then any local DNS resolution will fail.

To address this, this PR adds an attempt to dial the connection via the custom dialer, if the DNS resolution fails.

**Background**
While [implementing](https://github.com/grafana/grafana/pull/64630) the secure socks proxy in Grafana for MSSQL (where we allow datasources to go through a socks5 proxy with TLS to allow users to connect to datasources that live in a different network than where Grafana is running), we noticed that it would only work with connection strings that used ip addresses, not domain names.

We found this is because the dialConnection function tries to resolve DNS without using the custom dialer (so the connection is not sent through through the proxy). Since Grafana cannot reach the network without the proxy and it's a local domain name, it fails to connect.